### PR TITLE
looking at pydbus 0.5.1

### DIFF
--- a/dbus.py
+++ b/dbus.py
@@ -15,7 +15,8 @@ class Server(object):
         self.method_inargs = method_inargs
         self.method_outargs = method_outargs
 
-        bus.register_object(object_path=path, interface_info=interface_info, method_call_closure=self.on_method_call)
+        # bus.register_object(object_path=path, interface_info=interface_info, method_call_closure=self.on_method_call)
+        bus.publish(path,self)
 
     def run(self):
         self.loop.run()
@@ -72,5 +73,5 @@ if __name__ == '__main__':
     bus = SessionBus()
     bus.own_name(name = 'net.lvht')
 
-    foo = Foo(bus=bus.con, path='/net/lvht/Foo')
+    foo = Foo(bus=bus, path='/net/lvht/Foo')
     foo.run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 future
 evdev
 PyBluez
-pydbus==0.3
+#pydbus==0.5.1
+-e git://github.com/LEW21/pydbus.git@d6c1a27a2bd17280f63b0093872ffa89d8658f08#egg=pydbus


### PR DESCRIPTION
It's a start, at least we get on the right bus, and are calling the register.

```
# python dbus.py                                                               
(process:1467): GLib-GIO-CRITICAL **: g_bus_own_name_on_connection: assertion 'g_dbus_is_name (name) && !g_dbus_is_unique_name (name)' failed
Traceback (most recent call last):
  File "dbus.py", line 77, in <module>
    foo = Foo(bus=bus, path='/net/lvht/Foo')
  File "dbus.py", line 20, in __init__
    bus.publish(path,self)
  File "/root/btk/src/pydbus/pydbus/publication.py", line 33, in publish
    return Publication(self, bus_name, *objects)
  File "/root/btk/src/pydbus/pydbus/publication.py", line 26, in __init__
    self._at_exit(bus.register_object(path, object, node_info).__exit__)
  File "/root/btk/src/pydbus/pydbus/registration.py", line 125, in register_object
    return ObjectRegistration(self.con, path, interfaces, wrapper, own_wrapper=True)
  File "/root/btk/src/pydbus/pydbus/registration.py", line 105, in __init__
    ids = [con.register_object(path, interface, wrapper.call_method, wrapper.get_property, wrapper.set_property) for interface in interfaces]
TypeError: argument vtable: Expected Gio.DBusInterfaceVTable, but got pydbus.registration.instancemethod
```